### PR TITLE
a11y:footer: do not skip heading levels, no empty headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,18 +201,18 @@ For use on internal-only visibility, typically paired with **Slim Nav Dark** and
                 <p class="mb-0">
                     Designed, Developed and Supported by
                 </p>
-                <h5 class="mb-3">
+                <h2 class="h5 mb-3">
                     UCF IT App<span class="d-lg-inline d-md-none">lication</span> Development
-                </h5>
+                </h2>
                 <p>
                     &copy; <a href="https://www.ucf.edu/">University of Central Florida</a> |
                     <b><a href="https://ucf.service-now.com/ucfit?id=sc_cat_item&amp;sys_id=ae7581c4dbb5a20096b0fb37bf961954" class="external">Report Issue</a></b>
                 </p>
             </div>
             <div class="col-md-6 col-12 text-md-right text-sm-left">
-                <h5 class="mb-md-3 mb-sm-0">
+                <h2 class="h5 mb-md-3 mb-sm-0">
                     {{{Application Title}}}
-                </h5>
+                </h2>
                 <p>
                     Current Version: <b>{{{Semantic Version}}}-{{{Environment}}}</b><br>
                     Current User: <b>{{{Domain}}}\{{{Username}}}</b>

--- a/index.htm
+++ b/index.htm
@@ -122,18 +122,18 @@
                     <p class="mb-0">
                         Designed, Developed and Supported by
                     </p>
-                    <h5 class="mb-3">
+                    <h2 class="h5 mb-3">
                         UCF IT App<span class="d-lg-inline d-md-none">lication</span> Development
-                    </h5>
+                    </h2>
                     <p>
                         &copy; <a href="https://www.ucf.edu/">University of Central Florida</a> |
                         <b><a href="https://ucf.service-now.com/ucfit?id=sc_cat_item&sys_id=ae7581c4dbb5a20096b0fb37bf961954" class="external">Report Issue</a></b>
                     </p>
                 </div>
                 <div class="col-md-6 col-12 text-md-right text-sm-left">
-                    <h5 class="mb-md-3 mb-sm-0">
+                    <h2 class="h5 mb-md-3 mb-sm-0">
                         Minerva Style
-                    </h5>
+                    </h2>
                     <p>
                         Current Version: <b>v1.0.0-dev</b><br>
                         Current User: <b>GITHUB\fbrogers</b>

--- a/slim-nav-dark.htm
+++ b/slim-nav-dark.htm
@@ -129,18 +129,18 @@
                     <p class="mb-0">
                         Designed, Developed and Supported by
                     </p>
-                    <h5 class="mb-3">
+                    <h2 class="h5 mb-3">
                         UCF IT App<span class="d-lg-inline d-md-none">lication</span> Development
-                    </h5>
+                    </h2>
                     <p>
                         &copy; <a href="https://www.ucf.edu/">University of Central Florida</a> |
                         <b><a href="https://ucf.service-now.com/ucfit?id=sc_cat_item&sys_id=ae7581c4dbb5a20096b0fb37bf961954" class="external">Report Issue</a></b>
                     </p>
                 </div>
                 <div class="col-md-6 col-12 text-md-right text-sm-left">
-                    <h5 class="mb-md-3 mb-sm-0">
+                    <h2 class="h5 mb-md-3 mb-sm-0">
                         Minerva Style
-                    </h5>
+                    </h2>
                     <p>
                         Current Version: <b>v1.0.0-dev</b><br>
                         Current User: <b>GITHUB\fbrogers</b>

--- a/slim-nav-light.htm
+++ b/slim-nav-light.htm
@@ -110,18 +110,18 @@
                     <p class="mb-0">
                         Designed, Developed and Supported by
                     </p>
-                    <h5 class="mb-3">
+                    <h2 class="h5 mb-3">
                         UCF IT App<span class="d-lg-inline d-md-none">lication</span> Development
-                    </h5>
+                    </h2>
                     <p>
                         &copy; <a href="https://www.ucf.edu/">University of Central Florida</a> |
                         <b><a href="https://ucf.service-now.com/ucfit?id=sc_cat_item&sys_id=ae7581c4dbb5a20096b0fb37bf961954" class="external">Report Issue</a></b>
                     </p>
                 </div>
                 <div class="col-md-6 col-12 text-md-right text-sm-left">
-                    <h5 class="mb-md-3 mb-sm-0">
+                    <h2 class="h5 mb-md-3 mb-sm-0">
                         Minerva Style
-                    </h5>
+                    </h2>
                     <p>
                         Current Version: <b>v1.0.0-dev</b><br>
                         Current User: <b>GITHUB\fbrogers</b>

--- a/slim-nav-red.htm
+++ b/slim-nav-red.htm
@@ -128,18 +128,18 @@
                     <p class="mb-0">
                         Designed, Developed and Supported by
                     </p>
-                    <h5 class="mb-3">
+                    <h2 class="h5 mb-3">
                         UCF IT App<span class="d-lg-inline d-md-none">lication</span> Development
-                    </h5>
+                    </h2>
                     <p>
                         &copy; <a href="https://www.ucf.edu/">University of Central Florida</a> |
                         <b><a href="https://ucf.service-now.com/ucfit?id=sc_cat_item&sys_id=ae7581c4dbb5a20096b0fb37bf961954" class="external">Report Issue</a></b>
                     </p>
                 </div>
                 <div class="col-md-6 col-12 text-md-right text-sm-left">
-                    <h5 class="mb-md-3 mb-sm-0">
+                    <h2 class="h5 mb-md-3 mb-sm-0">
                         Minerva Style
-                    </h5>
+                    </h2>
                     <p>
                         Current Version: <b>v1.0.0-dev</b><br>
                         Current User: <b>GITHUB\fbrogers</b>


### PR DESCRIPTION
Use Bootstrap's .h5 class (etc.) to retain header styling and keep html semantic.

Instead of:
```
<h1>Title</h1>
{{NonHeaderContent}}
<h5 class="...">Heading</h5>
```
Do:
```
<h1>Title</h1>
{{NonHeaderContent}}
<h2 class="h5 ...">Heading</h2>
```

See:
http://wave.webaim.org/
https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh

Skipped headling level:
http://webaim.org/standards/508/checklist#standardo
https://webaim.org/standards/wcag/checklist#sc1.3.1
https://webaim.org/standards/wcag/checklist#sc2.4.1
https://webaim.org/standards/wcag/checklist#sc2.4.6